### PR TITLE
refactor: journal, trade, and ticker template updates

### DIFF
--- a/templates/journal.template.md
+++ b/templates/journal.template.md
@@ -4,6 +4,10 @@ Date in US: <% tp.date.yesterday("D MMMM YYYY") %>
 
 ## News & Summary
 
+- How is ES=F futures trading?
+- What news is on Yahoo Finance
+- Bear Bull Traders Premarket Show
+
 ![SPX Chart](../images/charts/<% tp.date.yesterday() %>/SPX.png)
 
 ## Selected Tickers

--- a/templates/journal.template.md
+++ b/templates/journal.template.md
@@ -1,7 +1,10 @@
-# <% tp.date.now() %> — Day <% tp.system.prompt("Day") %>
+# <% tp.date.now("D MMMM YYYY") %> — Day <% tp.system.prompt("Day") %>
+
+Date in US: <% tp.date.yesterday("D MMMM YYYY") %>
+
 ## News & Summary
 
-![SPX Chart](../images/charts/<% tp.date.now() %>/SPX.png)
+![SPX Chart](../images/charts/<% tp.date.yesterday() %>/SPX.png)
 
 ## Selected Tickers
 

--- a/templates/ticker.template.md
+++ b/templates/ticker.template.md
@@ -2,13 +2,34 @@
 
 ### <% ticker %>
 
-Identified from: 
+#### How did I find this stock?
 
-| Key         | Value | Classification | Source |
-| ----------- | ----- | -------------- | ------ |
-| Market Cap. |       |                |        |
-| Float       |       |                |        |
-| Avg. Volume |       |                |        |
-| ATR         |       |                |        |
+I might have found it from ZenBot scanner, the BBT premarket show, or whilst browsing news. When you reflect, answer questions like:
+
+- Was this a stock in play? Why or why not?
+- Was the stock trading smoothly or was it choppy?
+
+#### Why am I trading it?
+
+- What is the fundamental catalyst that makes this stock interesting? 
+- Will this stock be strong or weaker than the market?
+
+#### How will I trade it?
+
+Answer questions like:
+
+- What are the support & resistance levels?
+- What is my plan if it sets up to the long side? How about the short side?
+- What might my stop loss be? What might my profit window look like?
+
+#### Statistics
+
+| Key            | Value | Classification | Source |
+| -------------- | ----- | -------------- | ------ |
+| Market Cap.    |       |                |        |
+| Float          |       |                |        |
+| Avg. Volume    |       |                |        |
+| ATR (14 days)  |       |                |        |
+| Short Interest |       |                |        |
 
 ![<% ticker %> Chart](../images/charts/<% tp.file.title.split("_")[0] %>/<% ticker %>.png)

--- a/templates/trade.template.md
+++ b/templates/trade.template.md
@@ -8,16 +8,29 @@ trade_type = await tp.system.prompt("Trade Type");
 
 ### <% ticker %> <% dir %> (#<% count %>) — <% trade_time %>
 
-<% trade_type %>
+Trade type: <% trade_type %>
 
-Description.
+Provide an explanation of the trade, chronologically, while also answering questions like:
 
-#### #### What was good about this trade?
+- How did I find the opportunity to trade this stock?
+- What was my rationale for entry?
+- What was the quality of my entry from a risk:reward perspective? Did it go according to plan?
+- How much did I risk? How did you manage your position sizing?
+- How was my exit execution?
+- Did I take profit too early? 
 
-* Good line item
+#### Environmental
 
-#### What was bad about this trade?
+* What was my physical and emotional wellbeing when I took the trade?
 
-- Bad line item
+#### #### What went right about this trade?
+
+- How accurate was my technical analysis?
+- What contributed to this being a good trade?
+
+#### What was wrong about this trade?
+
+- Is there anything I could improve next time?
+- Did I lack discipline? Was I scared?
 
 ![Trade Chart](../images/trades/<% tp.file.title.split("_")[0] %>/<% ticker %>_<% count %>.png)

--- a/templates/trade.template.md
+++ b/templates/trade.template.md
@@ -2,16 +2,22 @@
 ticker = await tp.system.prompt("Ticker");
 dir = await tp.system.suggester(["Long", "Short"], ["Long", "Short"]);
 count = await tp.system.prompt("Count");
+trade_time = await tp.system.prompt("Trade Time");
+trade_type = await tp.system.prompt("Trade Type");
 %>
 
-### <% ticker %> <% dir %> (#<% count %>)
+### <% ticker %> <% dir %> (#<% count %>) — <% trade_time %>
 
-Entries:
-- Entry
+<% trade_type %>
 
-Exits:
-- Exit
+Description.
 
-P&L (%):
+#### #### What was good about this trade?
+
+* Good line item
+
+#### What was bad about this trade?
+
+- Bad line item
 
 ![Trade Chart](../images/trades/<% tp.file.title.split("_")[0] %>/<% ticker %>_<% count %>.png)


### PR DESCRIPTION
Ergonomic improvements made after few days of usage, as well as prompting suggestions from reading _How to Day Trade for a Living_.

# Journal changes:

* Fix the date in the title to be human-readable.
* Add a "Date in US" field underneath.
* Prompting questions around ES=F futures, news, and adding a link to the BBT premarket show.
* Fix the date of the SPX chart to be yesterday.

# Ticker changes:

* Prompting questions. How did I find this stock? Why am I trading it? How will I trade it?
* Update statistics to capture short interest.
* Indicate ATR is measured over a 14 day period.

# Trade changes:

* Require the selection of a trade type to create an entry.
* Append the trade time to the header of the trade.
* Add prompting questions about my rationale.
* Document environmental information, as well as preferring questions about what went right and wrong.