### PR TITLE
refactor: journal, trade, and ticker template updates

### DIFF
--- a/templates/journal.template.md
+++ b/templates/journal.template.md
@@ -1,6 +1,12 @@
-# <% tp.date.now() %> — Day <% tp.system.prompt("Day") %>
+# <% tp.date.now("D MMMM YYYY") %> — Day <% tp.system.prompt("Day") %>
+
+Date in US: <% tp.date.yesterday("D MMMM YYYY") %>
 
 ## News & Summary
+
+- How is ES=F futures trading?
+- What news is on Yahoo Finance
+- Bear Bull Traders Premarket Show
 
 ## Selected Tickers
 

--- a/templates/ticker.template.md
+++ b/templates/ticker.template.md
@@ -2,7 +2,7 @@
 
 ### <% ticker %>
 
-Identified from: 
+Identified from:
 
 | Key         | Value | Classification | Source |
 | ----------- | ----- | -------------- | ------ |

--- a/templates/trade.template.md
+++ b/templates/trade.template.md
@@ -1,7 +1,34 @@
-<%* 
+<%*
 ticker = await tp.system.prompt("Ticker");
 dir = await tp.system.suggester(["Long", "Short"], ["Long", "Short"]);
 count = await tp.system.prompt("Count");
+trade_time = await tp.system.prompt("Trade Time");
+trade_type = await tp.system.prompt("Trade Type");
 %>
 
-### <% ticker %> <% dir %> (#<% count %>)
+### <% ticker %> <% dir %> (#<% count %>) — <% trade_time %>
+
+Trade type: <% trade_type %>
+
+Provide an explanation of the trade, chronologically, while also answering questions like:
+
+- How did I find the opportunity to trade this stock?
+- What was my rationale for entry?
+- What was the quality of my entry from a risk:reward perspective? Did it go according to plan?
+- How much did I risk? How did you manage your position sizing?
+- How was my exit execution?
+- Did I take profit too early?
+
+#### Environmental
+
+* What was my physical and emotional wellbeing when I took the trade?
+
+#### #### What went right about this trade?
+
+- How accurate was my technical analysis?
+- What contributed to this being a good trade?
+
+#### What was wrong about this trade?
+
+- Is there anything I could improve next time?
+- Did I lack discipline? Was I scared?


### PR DESCRIPTION
Ergonomic improvements made after few days of usage, as well as prompting suggestions from reading _How to Day Trade for a Living_.

# Journal changes:

* Fix the date in the title to be human-readable.
* Add a "Date in US" field underneath.
* Prompting questions around ES=F futures, news, and adding a link to the BBT premarket show.

# Ticker changes:

* Prompting questions. How did I find this stock? Why am I trading it? How will I trade it?
* Update statistics to capture short interest.
* Indicate ATR is measured over a 14 day period.

# Trade changes:

* Require the selection of a trade type to create an entry.
* Append the trade time to the header of the trade.
* Add prompting questions about my rationale.
* Document environmental information, as well as preferring questions about what went right and wrong.