### PR TITLE
chore(expenses): add recent expenses

### DIFF
--- a/expenses.md
+++ b/expenses.md
@@ -39,15 +39,16 @@ Ordered from Amazon US. Total cost: NZ$234.26 (US$135.12)
 
 Medium term plan is to use the following tools while I establish proof of profitability:
 
-- DAS Trader Pro (Deluxe Plan, $150/month), with OTC/Options swapped for ARCA Book.
-- TradingView Premium
-	- Including U.S. Stock Markets bundle
+- DAS Trader Pro (Deluxe Plan), with OTC/options data swapped for the ARCABook feed (this swap is free of charge)
+- TradingView Premium.
+	- Including U.S. Stock Markets bundle.
+- Parallels Desktop for Mac to run DAS Trader Pro.
 
 Once profitability has been established and a track record built for several months, I could consider a switch to LightSpeed trader, whilst still maintaining a TradingView premium subscription for charts.
 
-- Lightspeed Trader (Reg-T Margin Account)
-- TradingView Premium
-	- Including U.S. Stock Markets bundle
+- Lightspeed Trader (Reg-T Margin Account).
+- TradingView Premium.
+	- Including U.S. Stock Markets bundle.
 
 ### MotiveWave
 
@@ -59,7 +60,7 @@ Subscribed to the _Pro_ version for one month to test its functionality. While t
 
 ### DAS Trader Pro
 
-Subscribed to the monthly Deluxe Edition
+Subscribed to the Deluxe Edition. This is a monthly subscription.
 
 | Service                       | Date Charged | Paid (USD) | Paid (NZD) |
 | ----------------------------- | ------------ | ---------- | ---------- |
@@ -75,6 +76,14 @@ Subscribed to the -60% off end of trial offer, paying for TradingView Premium an
 | US Stock Markets bundle |              | $119.40    |            |
 | GST                     |              | $66.49     |            |
 | Total                   | 11 June 2025 | $509.77    | $857.09    |
+
+### Parallels Desktop for Mac
+
+Necessary to run DAS Trader Pro. This is an annual subscription.
+
+| Service                                              | Date Charged | Paid (AUD) | Paid (NZD) |
+| ---------------------------------------------------- | ------------ | ---------- | ---------- |
+| Parallels Desktop for Mac Standard (Student Edition) | 22 June 2025 | $62.60     | $68.91     |
 
 ## Market Data
 

--- a/expenses.md
+++ b/expenses.md
@@ -37,13 +37,13 @@ Ordered from Amazon US. Total cost: NZ$234.26 (US$135.12)
 
 ## Tools, Services, & Platforms
 
-Medium term plan is to use the following tools while I establish proof of profitability.
+Medium term plan is to use the following tools while I establish proof of profitability:
 
 - DAS Trader Pro (Deluxe Plan, $150/month), with OTC/Options swapped for ARCA Book.
 - TradingView Premium
 	- Including U.S. Stock Markets bundle
 
-Once profitability has been established and a track record built for several months, will likely switch to Lightspeed Trader, whilst still maintaining a TradingView premium subscription for charts.
+Once profitability has been established and a track record built for several months, I could consider a switch to LightSpeed trader, whilst still maintaining a TradingView premium subscription for charts.
 
 - Lightspeed Trader (Reg-T Margin Account)
 - TradingView Premium

--- a/expenses.md
+++ b/expenses.md
@@ -37,21 +37,52 @@ Ordered from Amazon US. Total cost: NZ$234.26 (US$135.12)
 
 ## Tools, Services, & Platforms
 
-Currently considering:
+Medium term plan is to use the following tools while I establish proof of profitability.
 
-* MotiveWave Pro
-	* US$99/month, or one-time payment of US$1495 for 1 year of updates and support, with a additional 1 year of updates and support for US$225 thereafter.
-* Sierra Charts
-	* Service Package 11
-* DAS Trader Pro
+- DAS Trader Pro (Deluxe Plan, $150/month), with OTC/Options swapped for ARCA Book.
+- TradingView Premium
+	- Including U.S. Stock Markets bundle
 
-If the latter two, will likely use TradingView Premium (US$323.88/year) with TradingView Market Data (US$9.95/month) for charting.
+Once profitability has been established and a track record built for several months, will likely switch to Lightspeed Trader, whilst still maintaining a TradingView premium subscription for charts.
 
-## Subscription Data
+- Lightspeed Trader (Reg-T Margin Account)
+- TradingView Premium
+	- Including U.S. Stock Markets bundle
 
-I am currently subscribed to market depth data through IBKR, as this seems to be the most cost effective platform for real-time data.
+### MotiveWave
 
-### Level 1 Data
+Subscribed to the _Pro_ version for one month to test its functionality. While the software itself works well, the connection to the IBKR TWS API is inconsistent.
+
+| Service        | Date Charged | Paid (USD) | Paid (NZD) |
+| -------------- | ------------ | ---------- | ---------- |
+| MotiveWave Pro | 4 June 2025  | $99.00     | $167.54    |
+
+### DAS Trader Pro
+
+| Service                       | Date Charged | Paid (USD) | Paid (NZD) |
+| ----------------------------- | ------------ | ---------- | ---------- |
+| DAS Trader Pro Deluxe Edition |              |            |            |
+
+### TradingView
+
+Subscribed to the -60% off end of trial offer, paying for TradingView Premium and the U.S. Stock markets bundle.
+
+| Service                 | Date Charged | Paid (USD) | Paid (NZD) |
+| ----------------------- | ------------ | ---------- | ---------- |
+| TradingView Premium     |              | $323.88    |            |
+| US Stock Markets bundle |              | $119.40    |            |
+| GST                     |              | $66.49     |            |
+| Total                   | 11 June 2025 | $509.77    | $857.09    |
+
+## Market Data
+
+I currently receive market data through my DAS Trader Pro subscription as well as TradingView's market data bundle.
+
+### IBKR
+
+Discontinued as the Level 2 data is "pulsed", and provided by my trading platform (DAS Trader Pro).
+
+#### Level 1 Data
 
 Level 1 data provides best bid/ask, aka "top of book" real-time streaming quotes.
 
@@ -62,7 +93,8 @@ Level 1 data provides best bid/ask, aka "top of book" real-time streaming quotes
 | NYSE (Network A/CTA)(NP,L1)                                                | US$1.50/month     |
 | NYSE American, BATS, ARCA, IEX, and Regional Exchanges (Network B) (NP,L1) | US$1.50/month     |
 | **Sum**                                                                    | **US$5.50/month** |
-### Level 2 Data
+
+#### Level 2 Data
 
 Level 2 data provides real-time streaming market depth, i.e. the "order book", beyond the best bid and ask.
 
@@ -74,9 +106,18 @@ Level 2 data provides real-time streaming market depth, i.e. the "order book", b
 | NYSE OpenBook (NP,L2)             | US$25.00/month |
 | **Sum**                               | **US$60.50/month** |
 
-### Monthly Expenses to Date
+#### Monthly Expenses to Date
 
 | Month              | Paid (USD) | Paid (NZD) | Notes                                   |
 | ------------------ | ---------- | ---------- | --------------------------------------- |
 | May 2025 (Level 2) | N/A        | NZ$102.98  | Converted into USD by IBKR.             |
 | May 2025 (Level 1) | US$5.50    | N/A        | Paid from _Investments_ account in USD. |
+
+### dxfeed
+
+I used dxfeed to integrate historical tick data with MotiveWave, however since I am no longer using MotiveWave itself this became redundant.
+
+| Service                                 | Date Charged | Paid (USD) | Paid (NZD) |
+| --------------------------------------- | ------------ | ---------- | ---------- |
+| Consolidated US Equities Level 1 (NBBO) | 2 June 2025  | US$49      | $83.48     |
+| Nasdaq TotalView Market Depth           | 6 June 2025  | US$69      | $116.15    |

--- a/expenses.md
+++ b/expenses.md
@@ -121,3 +121,11 @@ I used dxfeed to integrate historical tick data with MotiveWave, however since I
 | --------------------------------------- | ------------ | ---------- | ---------- |
 | Consolidated US Equities Level 1 (NBBO) | 2 June 2025  | US$49      | $83.48     |
 | Nasdaq TotalView Market Depth           | 6 June 2025  | US$69      | $116.15    |
+
+## Ancillary
+
+Other purchases in support of trading. Total cost incurred to date: NZ$429.00
+
+| Item                                         | Cost (including shipping & GST) |
+| -------------------------------------------- | ------------------------------- |
+| Brother DCP-L3560CWD Colour Laser A4 Printer | NZ$429.00                       |

--- a/expenses.md
+++ b/expenses.md
@@ -59,9 +59,11 @@ Subscribed to the _Pro_ version for one month to test its functionality. While t
 
 ### DAS Trader Pro
 
+Subscribed to the monthly Deluxe Edition
+
 | Service                       | Date Charged | Paid (USD) | Paid (NZD) |
 | ----------------------------- | ------------ | ---------- | ---------- |
-| DAS Trader Pro Deluxe Edition |              |            |            |
+| DAS Trader Pro Deluxe Edition | 17 June 2025 | $150.00    | $260.55    |
 
 ### TradingView
 


### PR DESCRIPTION
Recent expenses:

- DAS Trader Pro Deluxe (US$150/month, ongoing)
- TradingView Premium + U.S. market data (US$509.77 for the first year, ongoing)
- Parallels Desktop for Mac (AU$62.60, ongoing)
- Brother Laser Printer (NZ$429.00)
- MotiveWave Pro (1× US$99/month, terminated) 
- dxfeed data subscriptions for MotiveWave Pro (US$49 & US$69 terminated)
- IBKR market data (US$5.50/month & US$60.50/month, terminated)